### PR TITLE
Fix extension activation.

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,11 +11,9 @@
   "categories": [
     "Other"
   ],
-  "activationEvents": [
-    "onCommand:extension.sayHello"
-  ],
   "main": "./out/src/extension",
   "activationEvents": [
+    "onCommand:extension.sayHello",
 	  "onLanguage:typescript",
     "onLanguage:javascript"
   ],

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
   ],
   "main": "./out/src/extension",
   "activationEvents": [
-    "onCommand:extension.sayHello",
     "onLanguage:typescript",
     "onLanguage:javascript"
   ],

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "main": "./out/src/extension",
   "activationEvents": [
     "onCommand:extension.sayHello",
-	  "onLanguage:typescript",
+    "onLanguage:typescript",
     "onLanguage:javascript"
   ],
   "scripts": {


### PR DESCRIPTION
This extension did not work for me, because of a duplicate object key in `package.json` (`activationEvents`).
I think I've fixed it with this PR (tested on my machine, did work).